### PR TITLE
Fix "NaN%" and syntax

### DIFF
--- a/abba/render.js
+++ b/abba/render.js
@@ -280,7 +280,7 @@ Abba.ResultsPresenter.prototype = {
         var baselineProportion = experiment.getBaselineProportion();
         var overallConversionBounds = {lowerBound: baselineProportion.lowerBound,
                                        upperBound: baselineProportion.upperBound};
-        var vars = variations.map(function(variation) {
+        var variationResults = variations.map(function(variation) {
             var outcome = experiment.getResults(variation.numSuccesses, variation.numTrials);
             overallConversionBounds.lowerBound = Math.min(overallConversionBounds.lowerBound,
                                                           outcome.proportion.lowerBound);
@@ -292,7 +292,7 @@ Abba.ResultsPresenter.prototype = {
         return {
             baselineProportion: baselineProportion,
             overallConversionBounds: overallConversionBounds,
-            variations: vars
+            variations: variationResults
         };
     },
 

--- a/abba/stats.js
+++ b/abba/stats.js
@@ -276,8 +276,8 @@ Abba.Experiment = function(numVariations, baselineNumSuccesses, baselineNumTrial
     this._baseline = new Abba.Proportion(baselineNumSuccesses, baselineNumTrials);
 
     this._numComparisons = Math.max(1, numVariations);
-    var alpha = intervalAlpha / this._numComparisons; // Bonferroni correction
-    this._intervalZCriticalValue = normal.inverseSurvival(alpha / 2);
+    var correctedAlpha = intervalAlpha / this._numComparisons; // Bonferroni correction
+    this._intervalZCriticalValue = normal.inverseSurvival(correctedAlpha / 2);
 };
 Abba.Experiment.prototype = {
     getBaselineProportion: function() {


### PR DESCRIPTION
## Overview:

Avoids displaying "NaN%" and provides some syntax fixes
Fix for Issue #2
## Changes:

**render.js**
- Display "N/A" instead of "NaN%" when 0 successes ( see _line 88_ )
- Syntax changes:
  - Added missing semi-colons
  - Renamed variables that were previously named same as function parameters
  - Changed formatting of code based on JS code linting

**stats.js**
- Syntax changes:
  - Use `===` for comparison
  - Added missing semi-colons
  - Renamed variables that were previously named same as function parameters
  - Changed formatting of code based on JS code linting
