### PR TITLE
Python: fix Python 3 compatibility

### DIFF
--- a/python/abba/stats.py
+++ b/python/abba/stats.py
@@ -2,8 +2,12 @@
 
 import collections
 import math
+import sys
 
 from scipy import stats
+
+if sys.version_info >= (3,):
+    xrange = range
 
 def get_z_critical_value(alpha, two_tailed=True):
     """


### PR DESCRIPTION
Added `sys` import and bound `xrange` to `range` in case in case the
Python version in use is version 3 or greater.