### PR TITLE
Usability: Hide checkbox when irrelevant

### DIFF
--- a/demo/abba.css
+++ b/demo/abba.css
@@ -168,6 +168,10 @@ input, button {
     width: 90%;
 }
 
+.inputs.single-variation .use-multiple-test-correction-ui {
+    display: none;
+}
+
 .inputs, .results {
     padding: 2em;
     max-width: 800px;

--- a/demo/app.js
+++ b/demo/app.js
@@ -135,6 +135,9 @@ Abba.InputsView.prototype = {
         inputs.variations.forEach(function(variation) {
             self._writeInputRow(self._createInputRow(), variation);
         });
+        
+        // hide the "Use multiple testing correction" toggle if only 1 variation exists
+        this._$form.toggleClass('single-variation', inputs.variations.length <= 1);
     }
 };
 


### PR DESCRIPTION
The "Use multiple testing correction" checkbox is visible and enabled by default. Confusingly, this checkbox has no effect at all unless the user clicks "Add another group" to append 2nd variation.

This change hides the checkbox in scenarios where it does not affect the calculation (<=1 variation).